### PR TITLE
Switch from attic-action to celler-action for cache uploads

### DIFF
--- a/.github/workflows/systems.yml
+++ b/.github/workflows/systems.yml
@@ -59,11 +59,14 @@ jobs:
             accept-flake-config = true
             fallback = true
             connect-timeout = 5
-      # Push what this job builds to celler (attic-compatible). Skipped on
-      # pull_request — fork PRs have no access to CELLER_TOKEN.
-      - name: Setup attic cache
+      # Push what this job builds to celler. Skipped on pull_request — fork
+      # PRs have no access to CELLER_TOKEN. Uses auscyber/celler-action (not
+      # ryanccn/attic-action) because celler requires the NAR info to be sent
+      # via an X-Celler-Nar-Info header, which the upstream attic client
+      # doesn't send — pushes with it fail with "X-Celler-Nar-Info must be set".
+      - name: Setup celler cache
         if: ${{ github.event_name != 'pull_request' }}
-        uses: ryanccn/attic-action@v0
+        uses: auscyber/celler-action@claude/celler-nar-info-header-irsrfq
         with:
           endpoint: https://cache.ivymect.in
           cache: main

--- a/aspects/base/caches.nix
+++ b/aspects/base/caches.nix
@@ -148,8 +148,10 @@ in
         # CI push token for GitHub Actions: scoped to sub=github, may push the
         # `main` cache. `nix run .#sync-ci-secrets` decrypts this and uploads
         # it as the CELLER_TOKEN GitHub Actions secret; systems.yml hands it to
-        # ryanccn/attic-action, which pushes every host it builds (celler JWTs
-        # are attic-compatible). (Previously this
+        # auscyber/celler-action, which pushes every host it builds. (Not
+        # ryanccn/attic-action -- celler's upload protocol needs an
+        # X-Celler-Nar-Info header that the upstream attic client never sends.)
+        # (Previously this
         # named `deps.cache_key` with no dependency declared, so it never
         # generated -- hence github_cache_key.age was missing on disk.)
         github_cache_key = {

--- a/aspects/tooling/ci.nix
+++ b/aspects/tooling/ci.nix
@@ -17,7 +17,9 @@
 #     straight from the flake's nixConfig -- everything derived from
 #     aspects/base/celler-keys.json -- with nothing hardcoded in the workflow.
 #   * `apps.sync-ci-secrets` mints + uploads the CELLER_TOKEN that
-#     ryanccn/attic-action pushes with (celler JWTs are attic-compatible).
+#     auscyber/celler-action pushes with (a fork of ryanccn/attic-action that
+#     uses the celler client instead of attic, since celler's upload protocol
+#     requires an X-Celler-Nar-Info header that upstream attic doesn't send).
 let
   self = inputs.self;
 


### PR DESCRIPTION
## Summary
This PR updates the CI cache upload mechanism to use `auscyber/celler-action` instead of `ryanccn/attic-action` to properly support celler's upload protocol requirements.

## Key Changes
- **systems.yml**: Updated the cache setup step to use `auscyber/celler-action@claude/celler-nar-info-header-irsrfq` instead of `ryanccn/attic-action@v0`
- **caches.nix**: Updated comments to reflect that the CELLER_TOKEN is now used with `auscyber/celler-action` instead of `ryanccn/attic-action`
- **ci.nix**: Updated documentation to explain that `auscyber/celler-action` is a fork of `ryanccn/attic-action` that uses the celler client

## Implementation Details
The switch was necessary because celler's upload protocol requires an `X-Celler-Nar-Info` header to be sent with uploads. The upstream attic client (`ryanccn/attic-action`) does not send this header, causing uploads to fail with "X-Celler-Nar-Info must be set". The `auscyber/celler-action` fork addresses this by using the celler client instead, which properly includes the required header in upload requests.

All comments have been updated to clarify this distinction and explain why the celler-specific action is necessary rather than the generic attic action.

https://claude.ai/code/session_017vBbfZpXUeieK1n25Y9Ggk