### PR TITLE
Point systems.yml at celler-action@main now that it's merged

### DIFF
--- a/.github/workflows/systems.yml
+++ b/.github/workflows/systems.yml
@@ -66,7 +66,7 @@ jobs:
       # doesn't send — pushes with it fail with "X-Celler-Nar-Info must be set".
       - name: Setup celler cache
         if: ${{ github.event_name != 'pull_request' }}
-        uses: auscyber/celler-action@claude/celler-nar-info-header-irsrfq
+        uses: auscyber/celler-action@main
         with:
           endpoint: https://cache.ivymect.in
           cache: main


### PR DESCRIPTION
## Summary
- `auscyber/celler-action#1` merged Celler client support into `main`
- The previous PR (#13) pinned the CI cache-push step to that feature branch (`auscyber/celler-action@claude/celler-nar-info-header-irsrfq`), which could be deleted at any time and silently break the cache push
- Update `.github/workflows/systems.yml` to track `auscyber/celler-action@main` instead

## Test plan
- [ ] CI (`systems.yml`) runs and the `Setup celler cache` step resolves `auscyber/celler-action@main` successfully

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_017vBbfZpXUeieK1n25Y9Ggk

---
_Generated by [Claude Code](https://claude.ai/code/session_017vBbfZpXUeieK1n25Y9Ggk)_