### PR TITLE
CI: install celler via inputs-from and pre-build+push it before the host matrix

### DIFF
--- a/.github/workflows/systems.yml
+++ b/.github/workflows/systems.yml
@@ -17,11 +17,14 @@ on:
 # `celler` builds and pushes the `celler` client itself (`.#celler`, exposed by
 # aspects/tooling/ci.nix) ahead of the host matrix, one leg per arch the matrix
 # can land on (mirrors `ci.nix`'s `supported` systems / nix-github-actions'
-# runner mapping). `build` depends on it, so by the time each host job installs
-# celler it can substitute the client from cache instead of building it from
-# source on every leg. Every `Setup celler cache` step uses `inputs-from: "."`
-# so the client version tracks this repo's own `celler` flake input / lock
-# entry rather than always floating on `github:blitz/celler`'s default branch.
+# runner mapping). It does NOT use auscyber/celler-action -- that action itself
+# needs a working celler client, which is what this job is producing, so it
+# instead wires the cache in as a plain nix substituter and dogfoods the
+# freshly built binary to log in and push itself. `build` depends on `celler`,
+# so by the time each host job installs celler (via celler-action, with
+# `inputs-from: "."` so the version tracks this repo's own `celler` flake
+# input/lock entry) it can substitute the client from cache instead of
+# building it from source on every leg.
 jobs:
   matrix:
     runs-on: ubuntu-latest
@@ -66,6 +69,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      # No auscyber/celler-action here — that action itself needs a working
+      # celler client, which is exactly what this job is building. The cache
+      # is wired up as a plain substituter (so a rebuild can pull a
+      # previously-pushed celler instead of building from source again), and
+      # the client that comes out of `nix build` pushes itself to the cache
+      # below -- dogfooding celler into its own cache instead of installing a
+      # separate copy just to do the push.
       - uses: cachix/install-nix-action@v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
@@ -74,18 +84,26 @@ jobs:
             accept-flake-config = true
             fallback = true
             connect-timeout = 5
-      # Skipped on pull_request — fork PRs have no access to CELLER_TOKEN, and
-      # without it there'd be nothing to push celler's own build to anyway.
-      - name: Setup celler cache
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: auscyber/celler-action@main
-        with:
-          endpoint: https://cache.ivymect.in
-          cache: main
-          token: ${{ secrets.CELLER_TOKEN }}
-          inputs-from: "."
+            extra-substituters = https://cache.ivymect.in/main
+            extra-trusted-public-keys = main:xS+QBlQtWPB/oX9un7feA68WGJRWfizG4C0YQUsmeN4=
       - name: Build celler
-        run: nix build --no-link --fallback --impure --print-out-paths ".#celler" | tee "$RUNNER_TEMP/out-paths"
+        id: build
+        run: |
+          set -euo pipefail
+          out="$(nix build --no-link --fallback --impure --print-out-paths ".#celler")"
+          echo "out=$out" | tee -a "$GITHUB_OUTPUT"
+      # Dogfood: log in and push with the celler binary we just built, rather
+      # than installing a second copy via celler-action. Skipped on
+      # pull_request — fork PRs have no access to CELLER_TOKEN.
+      - name: Push celler to cache
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          set -euo pipefail
+          bin="${{ steps.build.outputs.out }}/bin/celler"
+          "$bin" login --set-default main https://cache.ivymect.in "$CELLER_TOKEN"
+          "$bin" push main "${{ steps.build.outputs.out }}"
+        env:
+          CELLER_TOKEN: ${{ secrets.CELLER_TOKEN }}
 
   build:
     needs: [matrix, celler]

--- a/.github/workflows/systems.yml
+++ b/.github/workflows/systems.yml
@@ -10,9 +10,18 @@ on:
 # Dynamic matrix: the `matrix` job evaluates `.#ciMatrix.matrix` (nix-github-
 # actions, from aspects/tooling/ci.nix) at run time, and `build` fans out one
 # job per host from it. fail-fast: false -> one machine failing never stops the
-# others. Both jobs `accept-flake-config`, so substituters + trusted-public-keys
+# others. All jobs `accept-flake-config`, so substituters + trusted-public-keys
 # come from the flake's nixConfig (built from aspects/base/celler-keys.json) --
 # nothing hardcoded here.
+#
+# `celler` builds and pushes the `celler` client itself (`.#celler`, exposed by
+# aspects/tooling/ci.nix) ahead of the host matrix, one leg per arch the matrix
+# can land on (mirrors `ci.nix`'s `supported` systems / nix-github-actions'
+# runner mapping). `build` depends on it, so by the time each host job installs
+# celler it can substitute the client from cache instead of building it from
+# source on every leg. Every `Setup celler cache` step uses `inputs-from: "."`
+# so the client version tracks this repo's own `celler` flake input / lock
+# entry rather than always floating on `github:blitz/celler`'s default branch.
 jobs:
   matrix:
     runs-on: ubuntu-latest
@@ -40,8 +49,46 @@ jobs:
           fi
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
+  celler:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - system: x86_64-linux
+            os: ubuntu-24.04
+          - system: aarch64-linux
+            os: ubuntu-24.04-arm
+          - system: aarch64-darwin
+            os: macos-14
+    name: celler (${{ matrix.system }})
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes pipe-operators
+            accept-flake-config = true
+            fallback = true
+            connect-timeout = 5
+      # Skipped on pull_request — fork PRs have no access to CELLER_TOKEN, and
+      # without it there'd be nothing to push celler's own build to anyway.
+      - name: Setup celler cache
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: auscyber/celler-action@main
+        with:
+          endpoint: https://cache.ivymect.in
+          cache: main
+          token: ${{ secrets.CELLER_TOKEN }}
+          inputs-from: "."
+      - name: Build celler
+        run: nix build --no-link --fallback --impure --print-out-paths ".#celler" | tee "$RUNNER_TEMP/out-paths"
+
   build:
-    needs: matrix
+    needs: [matrix, celler]
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.matrix.outputs.matrix) }}
@@ -75,5 +122,6 @@ jobs:
           endpoint: https://cache.ivymect.in
           cache: main
           token: ${{ secrets.CELLER_TOKEN }}
+          inputs-from: "."
       - name: Build ${{ matrix.name }}
         run: nix build --no-link --fallback --impure --print-out-paths ".#${{ matrix.attr }}" | tee "$RUNNER_TEMP/out-paths"


### PR DESCRIPTION
## Summary
- `Setup celler cache` steps in the host build matrix now pass `inputs-from: "."`, so the celler client version tracks this repo's own `celler` flake input/lock entry instead of always floating on `github:blitz/celler`'s default branch.
- Added a `celler` job (one leg per arch the host matrix can land on: `x86_64-linux`, `aarch64-linux`, `aarch64-darwin`) that builds `.#celler` (already exposed by `aspects/tooling/ci.nix`) and pushes it to the cache *before* the host matrix runs, so host jobs can substitute the client from cache instead of rebuilding it from source on every leg.
- The `celler` job does **not** use `auscyber/celler-action` — that action itself needs a working celler client, which is exactly what the job is producing (circular). Instead it wires the cache in as a plain nix substituter (`extra-substituters`/`extra-trusted-public-keys` in the install-nix-action config) and dogfoods the freshly built binary to log in and push itself to the cache.
- `build` now depends on `[matrix, celler]`.

## Test plan
- [ ] `.github/workflows/systems.yml` runs on this PR; confirm the `celler` job builds and (on `push`, not `pull_request`) pushes for all three arches
- [ ] Confirm `build` matrix jobs still install celler successfully and pick up the cached client
- [ ] Confirm pushes are skipped (not failing) on `pull_request` events due to missing `CELLER_TOKEN`

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBB9HZNMxZAC5ewZxW3XjG)_