### PR TITLE
CI: only build celler when it's missing from the cache

### DIFF
--- a/.github/workflows/systems.yml
+++ b/.github/workflows/systems.yml
@@ -14,17 +14,20 @@ on:
 # come from the flake's nixConfig (built from aspects/base/celler-keys.json) --
 # nothing hardcoded here.
 #
-# `celler` builds and pushes the `celler` client itself (`.#celler`, exposed by
-# aspects/tooling/ci.nix) ahead of the host matrix, one leg per arch the matrix
-# can land on (mirrors `ci.nix`'s `supported` systems / nix-github-actions'
-# runner mapping). It does NOT use auscyber/celler-action -- that action itself
-# needs a working celler client, which is what this job is producing, so it
-# instead wires the cache in as a plain nix substituter and dogfoods the
-# freshly built binary to log in and push itself. `build` depends on `celler`,
-# so by the time each host job installs celler (via celler-action, with
-# `inputs-from: "."` so the version tracks this repo's own `celler` flake
-# input/lock entry) it can substitute the client from cache instead of
-# building it from source on every leg.
+# `celler` makes sure the `celler` client itself (`.#celler`, exposed by
+# aspects/tooling/ci.nix) is present in the cache ahead of the host matrix, one
+# leg per arch the matrix can land on (mirrors `ci.nix`'s `supported` systems /
+# nix-github-actions' runner mapping). It first evals the output path and
+# queries the cache directly for it -- only builds (and pushes) when it's
+# actually missing, so an unchanged celler costs one cheap query per run. It
+# does NOT use auscyber/celler-action -- that action itself needs a working
+# celler client, which is what this job may need to produce, so it instead
+# wires the cache in as a plain nix substituter and, when it does build,
+# dogfoods the freshly built binary to log in and push itself. `build` depends
+# on `celler`, so by the time each host job installs celler (via
+# celler-action, with `inputs-from: "."` so the version tracks this repo's own
+# `celler` flake input/lock entry) it can substitute the client from cache
+# instead of building it from source on every leg.
 jobs:
   matrix:
     runs-on: ubuntu-latest
@@ -70,11 +73,10 @@ jobs:
         with:
           submodules: recursive
       # No auscyber/celler-action here — that action itself needs a working
-      # celler client, which is exactly what this job is building. The cache
-      # is wired up as a plain substituter (so a rebuild can pull a
-      # previously-pushed celler instead of building from source again), and
-      # the client that comes out of `nix build` pushes itself to the cache
-      # below -- dogfooding celler into its own cache instead of installing a
+      # celler client, which is exactly what this job may need to produce. The
+      # cache is wired up as a plain substituter instead, and if a build turns
+      # out to be necessary below, the resulting client pushes itself to the
+      # cache -- dogfooding celler into its own cache instead of installing a
       # separate copy just to do the push.
       - uses: cachix/install-nix-action@v31
         with:
@@ -86,22 +88,37 @@ jobs:
             connect-timeout = 5
             extra-substituters = https://cache.ivymect.in/main
             extra-trusted-public-keys = main:xS+QBlQtWPB/oX9un7feA68WGJRWfizG4C0YQUsmeN4=
+      # Eval only -- computes the output path without building or substituting
+      # anything -- then asks the cache directly whether that path already
+      # exists there. Cheap, and means a re-run with nothing changed does no
+      # work beyond this query.
+      - name: Check whether celler is already cached
+        id: check
+        run: |
+          set -euo pipefail
+          out="$(nix eval --impure --raw ".#celler.outPath")"
+          echo "out=$out" | tee -a "$GITHUB_OUTPUT"
+          if nix path-info --store https://cache.ivymect.in/main "$out" >/dev/null 2>&1; then
+            echo "celler already in the cache, nothing to build" >&2
+            echo "cached=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "cached=false" | tee -a "$GITHUB_OUTPUT"
+          fi
       - name: Build celler
         id: build
-        run: |
-          set -euo pipefail
-          out="$(nix build --no-link --fallback --impure --print-out-paths ".#celler")"
-          echo "out=$out" | tee -a "$GITHUB_OUTPUT"
+        if: ${{ steps.check.outputs.cached != 'true' }}
+        run: nix build --no-link --fallback --impure --print-out-paths ".#celler"
       # Dogfood: log in and push with the celler binary we just built, rather
-      # than installing a second copy via celler-action. Skipped on
-      # pull_request — fork PRs have no access to CELLER_TOKEN.
+      # than installing a second copy via celler-action. Skipped when celler
+      # was already cached, and on pull_request — fork PRs have no access to
+      # CELLER_TOKEN.
       - name: Push celler to cache
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ steps.check.outputs.cached != 'true' && github.event_name != 'pull_request' }}
         run: |
           set -euo pipefail
-          bin="${{ steps.build.outputs.out }}/bin/celler"
+          bin="${{ steps.check.outputs.out }}/bin/celler"
           "$bin" login --set-default main https://cache.ivymect.in "$CELLER_TOKEN"
-          "$bin" push main "${{ steps.build.outputs.out }}"
+          "$bin" push main "${{ steps.check.outputs.out }}"
         env:
           CELLER_TOKEN: ${{ secrets.CELLER_TOKEN }}
 


### PR DESCRIPTION
Eval the output path and query the cache for it first; build (and dogfood-push) only when that lookup comes back empty, so a re-run with nothing changed costs one cheap path-info query instead of a rebuild.


Claude-Session: https://claude.ai/code/session_01CBB9HZNMxZAC5ewZxW3XjG