### PR TITLE
CI: cache the Nix store across jobs via a shared composite action

### DIFF
--- a/.github/actions/nix-cache/action.yml
+++ b/.github/actions/nix-cache/action.yml
@@ -1,0 +1,28 @@
+name: "Restore and save Nix store"
+description: "Restore/save the Nix store cache across runs so eval and builds don't start cold every job."
+
+runs:
+  using: "composite"
+  steps:
+    - name: Restore and save Nix store
+      uses: nix-community/cache-nix-action@v7
+      with:
+        # restore and save a cache using this key
+        primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+        # if there's no cache hit, restore a cache by this prefix
+        restore-prefixes-first-match: nix-${{ runner.os }}-
+        # collect garbage until the Nix store size (in bytes) is at most this number
+        # before trying to save a new cache
+        # 1G = 1073741824
+        gc-max-store-size-linux: 1G
+        # do purge caches
+        purge: true
+        # purge all versions of the cache
+        purge-prefixes: nix-${{ runner.os }}-
+        # created more than this number of seconds ago
+        purge-created: 0
+        # or last accessed this duration (ISO 8601 duration format)
+        # before the start of the `Post Restore and save Nix store` phase
+        purge-last-accessed: P1DT12H
+        # except any version with the key that is the same as the `primary-key`
+        purge-primary-key: never

--- a/.github/workflows/systems.yml
+++ b/.github/workflows/systems.yml
@@ -45,6 +45,7 @@ jobs:
             accept-flake-config = true
             fallback = true
             connect-timeout = 5
+      - uses: ./.github/actions/nix-cache
       - id: set
         run: |
           set -euo pipefail
@@ -88,6 +89,7 @@ jobs:
             connect-timeout = 5
             extra-substituters = https://cache.ivymect.in/main
             extra-trusted-public-keys = main:xS+QBlQtWPB/oX9un7feA68WGJRWfizG4C0YQUsmeN4=
+      - uses: ./.github/actions/nix-cache
       # Eval only -- computes the output path without building or substituting
       # anything -- then asks the cache directly whether that path already
       # exists there. Cheap, and means a re-run with nothing changed does no
@@ -141,6 +143,7 @@ jobs:
             accept-flake-config = true
             fallback = true
             connect-timeout = 5
+      - uses: ./.github/actions/nix-cache
       # Push what this job builds to celler. Skipped on pull_request — fork
       # PRs have no access to CELLER_TOKEN. Uses auscyber/celler-action (not
       # ryanccn/attic-action) because celler requires the NAR info to be sent


### PR DESCRIPTION
Factors the nix-community/cache-nix-action@v7 restore/save/GC/purge config into .github/actions/nix-cache so it's written once and referenced from every job (matrix, celler, build) right after Nix is installed, instead of repeating the block per job. Keeps eval and builds warm between runs.


Claude-Session: https://claude.ai/code/session_01CBB9HZNMxZAC5ewZxW3XjG