### PR TITLE
CI: fix "A sequence was not expected" in build-host.yml matrix.os input

### DIFF
--- a/.github/workflows/build-host.yml
+++ b/.github/workflows/build-host.yml
@@ -16,7 +16,12 @@ on:
 jobs:
   build:
     name: ${{ inputs.name }}
-    runs-on: ${{ inputs.os }}
+    # inputs.os is JSON-encoded by the caller (systems.yml) because
+    # nix-github-actions' matrix rows can have `os` as a list of runner
+    # labels rather than a plain string -- workflow_call inputs are typed
+    # `string` only, so a list value fails evaluation ("A sequence was not
+    # expected") unless it's round-tripped through toJSON/fromJSON like this.
+    runs-on: ${{ fromJSON(inputs.os) }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/systems.yml
+++ b/.github/workflows/systems.yml
@@ -142,7 +142,7 @@ jobs:
     uses: ./.github/workflows/build-host.yml
     with:
       name: ${{ matrix.name }}
-      os: ${{ matrix.os }}
+      os: ${{ toJSON(matrix.os) }}
       attr: ${{ matrix.attr }}
     secrets: inherit
 
@@ -154,6 +154,6 @@ jobs:
     uses: ./.github/workflows/build-host.yml
     with:
       name: ${{ matrix.name }}
-      os: ${{ matrix.os }}
+      os: ${{ toJSON(matrix.os) }}
       attr: ${{ matrix.attr }}
     secrets: inherit


### PR DESCRIPTION
## Summary
The last run on `master` (run 30099618486) failed: `matrix`, `celler-x86_64-linux`, `celler-aarch64-linux`, and `celler-aarch64-darwin` all succeeded, but `build`/`build-darwin` never started — GitHub errors while evaluating the reusable-workflow `with:` inputs, before either job is created.

Root cause: nix-github-actions' matrix rows can have `os` as a *list* of runner labels rather than a plain string. `runs-on: ${{ matrix.os }}` (the old design) worked regardless, since `runs-on:` natively accepts a string or a list. `build-host.yml`'s `os` input is declared `type: string` though, and GitHub type-checks `with:` values against that at evaluation time — a list value fails with exactly "A sequence was not expected".

Fix: round-trip `os` through `toJSON`/`fromJSON` between caller and callee, so it works whether the value is a string or a list.

## Test plan
- [ ] Next run of `.github/workflows/systems.yml` on `master`: `build`/`build-darwin` jobs actually appear and run (not just the 4 gate/matrix jobs)
- [ ] Each host build lands on the correct runner (`runs-on` resolves correctly for both string and list `os` values)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBB9HZNMxZAC5ewZxW3XjG)_