### PR TITLE
Filter internal aspects from diagram output

### DIFF
--- a/aspects/docs/default.nix
+++ b/aspects/docs/default.nix
@@ -46,6 +46,11 @@ in
             name = hostName;
           };
 
+          # Drop pipeline noise (<anon>, resolve(...) bookkeeping, policy
+          # plumbing) so the rendered graph reflects aspects a user actually
+          # declared instead of every internal resolution step.
+          gFiltered = diagram.graph.filterUserAspects g;
+
           rc = diagram.renderContext {
             inherit pkgs;
             theme = diagram.themeFromBase16 {
@@ -55,9 +60,9 @@ in
           };
         in
         {
-          mermaid = diagram.toMermaid g;
-          svg = rc.mmdSourceToSvg hostName (diagram.toMermaid g);
-          dot = diagram.toDot g;
+          mermaid = diagram.toMermaid gFiltered;
+          svg = rc.mmdSourceToSvg hostName (diagram.toMermaid gFiltered);
+          dot = diagram.toDot gFiltered;
         };
 
       # Build diagrams for all hosts


### PR DESCRIPTION
## Summary
This change filters out internal pipeline noise from generated diagrams, ensuring that the rendered output reflects only the aspects explicitly declared by users rather than every internal resolution step.

## Key Changes
- Added `gFiltered` variable that applies `filterUserAspects` to the graph before rendering
- Updated all diagram output formats (Mermaid, SVG, and Dot) to use the filtered graph instead of the raw graph
- This removes anonymous nodes, resolution bookkeeping, and policy plumbing from the final diagrams

## Implementation Details
The filtering is applied once to create `gFiltered`, which is then reused across all three output formats (Mermaid, SVG via Mermaid source, and Dot). This ensures consistency across all diagram representations while avoiding redundant filtering operations.

https://claude.ai/code/session_01VHytarYed6m1DsV4ctmC52